### PR TITLE
lib: refactor fs usage in esm/resolve.js to use dot notation instead destructuring

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -25,11 +25,7 @@ const {
 } = primordials;
 const internalFS = require('internal/fs/utils');
 const { BuiltinModule } = require('internal/bootstrap/loaders');
-const {
-  realpathSync,
-  statSync,
-  Stats,
-} = require('fs');
+const fs = require('fs');
 const { getOptionValue } = require('internal/options');
 // Do not eagerly grab .manifest, it may be in TDZ
 const policy = getOptionValue('--experimental-policy') ?
@@ -140,14 +136,14 @@ const realpathCache = new SafeMap();
  * @returns {import('fs').Stats}
  */
 const tryStatSync =
-  (path) => statSync(path, { throwIfNoEntry: false }) ?? new Stats();
+  (path) => fs.statSync(path, { throwIfNoEntry: false }) ?? new fs.Stats();
 
 /**
  * @param {string | URL} url
  * @returns {boolean}
  */
 function fileExists(url) {
-  return statSync(url, { throwIfNoEntry: false })?.isFile() ?? false;
+  return fs.statSync(url, { throwIfNoEntry: false })?.isFile() ?? false;
 }
 
 /**
@@ -233,7 +229,7 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
   }
 
   if (!preserveSymlinks) {
-    const real = realpathSync(path, {
+    const real = fs.realpathSync(path, {
       [internalFS.realpathCacheKey]: realpathCache,
     });
     const { search, hash } = resolved;


### PR DESCRIPTION
Testing CI to start